### PR TITLE
Update setup_windows.md

### DIFF
--- a/docs/guide/host_pc/setup_windows.md
+++ b/docs/guide/host_pc/setup_windows.md
@@ -55,7 +55,7 @@ Note: if you are using ZSH (you'll know if you are), you won't be able to run `p
 If you have an NVidia card, you should update to the lastest drivers and [install Cuda SDK](https://www.tensorflow.org/install/gpu#windows_setup). 
 
 ```bash
-conda install tensorflow-gpu==2.2.0
+pip install tensorflow-gpu==2.2.0
 ```
 
 * Optionally configure PyTorch to use GPU - only for NVidia Graphics cards


### PR DESCRIPTION
I'm not sure if it's correct, but 

```
(donkey) C:\donkeycar\projects\mysim>conda install tensorflow-gpu==2.2.0
Collecting package metadata (current_repodata.json): done
Solving environment: failed with initial frozen solve. Retrying with flexible solve.
Collecting package metadata (repodata.json): done
Solving environment: failed with initial frozen solve. Retrying with flexible solve.

PackagesNotFoundError: The following packages are not available from current channels:

  - tensorflow-gpu==2.2.0

Current channels:

  - https://repo.anaconda.com/pkgs/main/win-64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/r/win-64
  - https://repo.anaconda.com/pkgs/r/noarch
  - https://repo.anaconda.com/pkgs/msys2/win-64
  - https://repo.anaconda.com/pkgs/msys2/noarch

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org

and use the search bar at the top of the page.

```
----------
doesnt work

and only the following is working

```
(donkey) C:\donkeycar\projects\mysim>pip install tensorflow-gpu==2.2.0
Collecting tensorflow-gpu==2.2.0
  Downloading tensorflow_gpu-2.2.0-cp37-cp37m-win_amd64.whl (460.4 MB)
     |████████████████████████████████| 460.4 MB 12 kB/s
Requirement already satisfied: grpcio>=1.8.6 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorflow-gpu==2.2.0) (1.36.1)
Requirement already satisfied: six>=1.12.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorflow-gpu==2.2.0) (1.16.0)
Requirement already satisfied: opt-einsum>=2.3.2 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (3.3.0)
Requirement already satisfied: wrapt>=1.11.1 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorflow-gpu==2.2.0) (1.12.1)
Requirement already satisfied: termcolor>=1.1.0 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (1.1.0)
Requirement already satisfied: tensorboard<2.3.0,>=2.2.0 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (2.2.2)
Collecting tensorflow-gpu-estimator<2.3.0,>=2.2.0
  Downloading tensorflow_gpu_estimator-2.2.0-py2.py3-none-any.whl (470 kB)
     |████████████████████████████████| 470 kB ...
Requirement already satisfied: scipy==1.4.1 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (1.4.1)
Requirement already satisfied: keras-preprocessing>=1.1.0 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (1.1.2)
Requirement already satisfied: wheel>=0.26 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorflow-gpu==2.2.0) (0.36.2)
Requirement already satisfied: google-pasta>=0.1.8 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (0.2.0)
Requirement already satisfied: absl-py>=0.7.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorflow-gpu==2.2.0) (0.13.0)
Requirement already satisfied: numpy<2.0,>=1.16.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorflow-gpu==2.2.0) (1.20.2)
Requirement already satisfied: astunparse==1.6.3 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (1.6.3)
Requirement already satisfied: protobuf>=3.8.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorflow-gpu==2.2.0) (3.14.0)
Requirement already satisfied: gast==0.3.3 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (0.3.3)
Requirement already satisfied: h5py<2.11.0,>=2.10.0 in c:\users\altex\appdata\roaming\python\python37\site-packages (from tensorflow-gpu==2.2.0) (2.10.0)
Requirement already satisfied: google-auth<2,>=1.6.3 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (1.32.0)
Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (1.6.0)
Requirement already satisfied: werkzeug>=0.11.15 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (1.0.1)
Requirement already satisfied: markdown>=2.6.8 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (3.3.4)
Requirement already satisfied: requests<3,>=2.21.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (2.25.1)
Requirement already satisfied: setuptools>=41.0.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (52.0.0.post20210125)
Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (0.4.4)
Requirement already satisfied: cachetools<5.0,>=2.0.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from google-auth<2,>=1.6.3->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (4.2.2)
Requirement already satisfied: pyasn1-modules>=0.2.1 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from google-auth<2,>=1.6.3->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (0.2.8)
Requirement already satisfied: rsa<5,>=3.1.4 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from google-auth<2,>=1.6.3->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (4.7.2)
Requirement already satisfied: requests-oauthlib>=0.7.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (1.3.0)
Requirement already satisfied: importlib-metadata in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from markdown>=2.6.8->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (3.10.0)
Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from pyasn1-modules>=0.2.1->google-auth<2,>=1.6.3->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (0.4.8)
Requirement already satisfied: urllib3<1.27,>=1.21.1 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from requests<3,>=2.21.0->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (1.26.4)
Requirement already satisfied: certifi>=2017.4.17 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from requests<3,>=2.21.0->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (2021.5.30)
Requirement already satisfied: chardet<5,>=3.0.2 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from requests<3,>=2.21.0->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (3.0.4)
Requirement already satisfied: idna<3,>=2.5 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from requests<3,>=2.21.0->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (2.10)
Requirement already satisfied: oauthlib>=3.0.0 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (3.1.0)
Requirement already satisfied: zipp>=0.5 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from importlib-metadata->markdown>=2.6.8->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (3.4.1)
Requirement already satisfied: typing-extensions>=3.6.4 in c:\donkeycar\miniconda3\envs\donkey\lib\site-packages (from importlib-metadata->markdown>=2.6.8->tensorboard<2.3.0,>=2.2.0->tensorflow-gpu==2.2.0) (3.7.4.3)
Installing collected packages: tensorflow-gpu-estimator, tensorflow-gpu
Successfully installed tensorflow-gpu-2.2.0 tensorflow-gpu-estimator-2.2.0
```