### PR TITLE
pip3 is not installed by default

### DIFF
--- a/docs/guide/host_pc/setup_windows.md
+++ b/docs/guide/host_pc/setup_windows.md
@@ -155,6 +155,8 @@ The Windows Subsystem for Linux (WSL) lets developers run a GNU/Linux environmen
 
 * Install `python3` using `sudo apt install python3`
 
+* Install `pip3` using `sudo apt install pip3`
+
 * Change to a directory that you would like to use as the head of all your projects.
 
 ```bash


### PR DESCRIPTION
When installing via apt-get pip3 is not installed by default and needs to be installed separately