### PR TITLE
Update simulator.md

### DIFF
--- a/docs/guide/simulator.md
+++ b/docs/guide/simulator.md
@@ -82,7 +82,7 @@ As you drive, this will create a tub of records in your data dir as usual.
 You will not need to rsync your data, as it was recorded and resides locally. You can train as usual:
 
 ```bash
-python manage.py train --model models/mypilot.h5
+python train.py --tub=data --model models/mypilot.h5
 ```
 
 ## Test


### PR DESCRIPTION
On a windows 10 installation the instructions are not up to date. 
I've updated the training line to use train.py and include the --tub=data option. (as suggested by naisy#6520 in the donkey discord software channel)