### PR TITLE
Add instructions for connecting xbox controller to jetson nano

### DIFF
--- a/docs/parts/controllers.md
+++ b/docs/parts/controllers.md
@@ -230,17 +230,17 @@ sudo reboot
 - Unpair (forget) the controller first if you already tried to pair it, then pair it again.  You can do this with the Bluetooth Manager GUI appliation that ships with Jetpack or if you are using command line, then use bluetoothctl:
 
   - Open terminal and type:
-```
-bluetoothctl
-```
+    ```
+    bluetoothctl
+    ```
   - then you should see the list of devices you have paired with and their corresponding MAC address. If you do not, type:
-```
-paired-devices
-```
+    ```
+    paired-devices
+    ```
   - To un-pair a device type (replace aa:bb:cc:dd:ee:ff with the MAC address of the device to un-pair):
-```
-remove aa:bb:cc:dd:ee:ff
-```
+    ```
+    remove aa:bb:cc:dd:ee:ff
+    ```
 - Pair your device using either Bluetooth Manager GUI or bluetoothctl (see RaspberryPi OS instruction starting with `sudo bluetoothctl`)
 
 Once paired you should have a solid light on the xbox button and a stable bluetooth connection.

--- a/docs/parts/controllers.md
+++ b/docs/parts/controllers.md
@@ -240,6 +240,7 @@ sudo reboot
   - To un-pair a device type (replace aa:bb:cc:dd:ee:ff with the MAC address of the device to un-pair):
     ```
     remove aa:bb:cc:dd:ee:ff
+    exit
     ```
 - Pair your device using either Bluetooth Manager GUI or bluetoothctl (see RaspberryPi OS instruction starting with `sudo bluetoothctl`)
 

--- a/docs/parts/controllers.md
+++ b/docs/parts/controllers.md
@@ -196,6 +196,50 @@ This code presumes the built-in linux driver for 'Xbox Wireless Controller'; thi
 
 The XBox One controller requires that the bluetooth disable_ertm parameter be set to true; to do this:
 
+#### **Jetson Nano**
+Adapted from: https://www.roboticsbuildlog.com/hardware/xbox-one-controller-with-nvidia-jetson-nano
+
+1. Install these python libraries before we disable ertm.
+```
+sudo apt-get install nano
+sudo apt-get install evtest
+```
+
+- To call evtest:
+```
+evtest /dev/input/event<event no.>
+```
+
+2. Add Non-root access to your input folder:
+```
+sudo usermod -a -G dialout $USER
+sudo reboot
+```
+
+3. Install sysfsutils
+```
+sudo apt-get install sysfsutils
+```
+4.  Edit the config to disable bluetooth ertm
+```
+sudo nano /etc/sysfs.conf
+```
+- Append this to the end of the config
+```
+/module/bluetooth/parameters/disable_ertm=1
+```
+5. Reboot your computer
+```
+sudo reboot
+```
+6. Re-pair the Xbox One Bluetooth Controller
+- Unpair the controller first, then pair it again.
+
+You should now have a solid light on the xbox button and a stable bluetooth connection.
+
+
+#### **RaspberryPi OS**
+
 * edit the file `/etc/modprobe.d/xbox_bt.conf`  (that may create the file; it is commonly not there by default)
 * add the line: `options bluetooth disable_ertm=1`
 * reboot so that this takes affect.

--- a/docs/parts/controllers.md
+++ b/docs/parts/controllers.md
@@ -202,12 +202,6 @@ Adapted from: https://www.roboticsbuildlog.com/hardware/xbox-one-controller-with
 1. Install these python libraries before we disable ertm.
 ```
 sudo apt-get install nano
-sudo apt-get install evtest
-```
-
-- To call evtest:
-```
-evtest /dev/input/event<event no.>
 ```
 
 2. Add Non-root access to your input folder:
@@ -233,9 +227,23 @@ sudo nano /etc/sysfs.conf
 sudo reboot
 ```
 6. Re-pair the Xbox One Bluetooth Controller
-- Unpair the controller first, then pair it again.
+- Unpair (forget) the controller first if you already tried to pair it, then pair it again.  You can do this with the Bluetooth Manager GUI appliation that ships with Jetpack or if you are using command line, then use bluetoothctl:
 
-You should now have a solid light on the xbox button and a stable bluetooth connection.
+  - Open terminal and type:
+```
+bluetoothctl
+```
+  - then you should see the list of devices you have paired with and their corresponding MAC address. If you do not, type:
+```
+paired-devices
+```
+  - To un-pair a device type (replace aa:bb:cc:dd:ee:ff with the MAC address of the device to un-pair):
+```
+remove aa:bb:cc:dd:ee:ff
+```
+- Pair your device using either Bluetooth Manager GUI or bluetoothctl (see RaspberryPi OS instruction starting with `sudo bluetoothctl`)
+
+Once paired you should have a solid light on the xbox button and a stable bluetooth connection.
 
 
 #### **RaspberryPi OS**


### PR DESCRIPTION
Adapted from https://www.roboticsbuildlog.com/hardware/xbox-one-controller-with-nvidia-jetson-nano