### PR TITLE
pip -> pip3 in rpi setup

### DIFF
--- a/docs/guide/robot_sbc/setup_raspberry_pi.md
+++ b/docs/guide/robot_sbc/setup_raspberry_pi.md
@@ -222,13 +222,13 @@ cd projects
 git clone https://github.com/autorope/donkeycar
 cd donkeycar
 git checkout master
-pip install -e .[pi]
-pip install numpy --upgrade
+pip3 install -e .[pi]
+pip3 install numpy --upgrade
 
 curl -sc /tmp/cookie "https://drive.google.com/uc?export=download&id=1DCfoSwlsdX9X4E3pLClE1z0fvw8tFESP" > /dev/null
 CODE="$(awk '/_warning_/ {print $NF}' /tmp/cookie)"
 curl -Lb /tmp/cookie "https://drive.google.com/uc?export=download&confirm=${CODE}&id=1DCfoSwlsdX9X4E3pLClE1z0fvw8tFESP" -o tensorflow-2.2.0-cp37-cp37m-linux_armv7l.whl
-pip install tensorflow-2.2.0-cp37-cp37m-linux_armv7l.whl
+pip3 install tensorflow-2.2.0-cp37-cp37m-linux_armv7l.whl
 ```
 
 You can validate your tensorflow install with


### PR DESCRIPTION
1. `pip install -e .[pi]` generates error: "Failed building wheel for h5py" -> I changed the line to `pip3 install -e .[pi]` - no error after. 

1. `pip install tensorflow-2.2.0-cp37-cp37m-linux_armv7l.whl` generates error: "tensorflow-2.2.0-cp37-cp37m-linux_armv7l.whl is not a supported wheel on this platform` - I changed to `pip install tensorflow-2.2.0-cp37-cp37m-linux_armv7l.whl` and no error after.