### PR TITLE
because raspbian buster InRelease changed its Suite value

### DIFF
--- a/docs/guide/robot_sbc/setup_raspberry_pi.md
+++ b/docs/guide/robot_sbc/setup_raspberry_pi.md
@@ -161,7 +161,7 @@ or via Putty.
 ## Step 6: Update and Upgrade
 
 ```bash
-sudo apt-get update
+sudo apt-get update --allow-releaseinfo-change
 sudo apt-get upgrade
 ```
 


### PR DESCRIPTION
required change to complete https://docs.donkeycar.com/guide/robot_sbc/setup_raspberry_pi/

background: https://askubuntu.com/a/989941/1556490

related to: https://github.com/autorope/donkeydocs/issues/27