### PR TITLE
Francisduvivier fix env activate for screen

### DIFF
--- a/docs/guide/robot_sbc/setup_jetson_nano.md
+++ b/docs/guide/robot_sbc/setup_jetson_nano.md
@@ -40,7 +40,7 @@ sudo apt-get install -y openmpi-doc openmpi-bin libopenmpi-dev libopenblas-dev
 ```bash
 pip3 install virtualenv
 python3 -m virtualenv -p python3 env --system-site-packages
-echo "source env/bin/activate" >> ~/.bashrc
+echo "source ~/env/bin/activate" >> ~/.bashrc
 source ~/.bashrc
 ```
 

--- a/docs/guide/robot_sbc/setup_raspberry_pi.md
+++ b/docs/guide/robot_sbc/setup_raspberry_pi.md
@@ -203,7 +203,7 @@ This needs to be done only once:
 
 ```bash
 python3 -m virtualenv -p python3 env --system-site-packages
-echo "source env/bin/activate" >> ~/.bashrc
+echo "source ~/env/bin/activate" >> ~/.bashrc
 source ~/.bashrc
 ```
 


### PR DESCRIPTION
I noticed when using the `screen` (builtin in the debian distro) command on the raspberry pi, that the env activation did not work when I used it from the mycar dir.
This PR is for fixing that.