### PR TITLE
Automatically activate `donkey` Python environment at login

### DIFF
--- a/docs/guide/robot_sbc/setup_jetson_nano.md
+++ b/docs/guide/robot_sbc/setup_jetson_nano.md
@@ -280,6 +280,7 @@ Also install tensorflow in the last step
 
 ```bash
 mamba env create -f install/envs/jetson46.yml
+echo >> ~/.bashrc conda activate donkey
 conda activate donkey
 conda update pip
 pip install -e .[nano]


### PR DESCRIPTION
Update to the traditional `echo "source ~/env/bin/activate" >> ~/.bashrc`