### PR TITLE
Correct docs for rotation related sim APIs

### DIFF
--- a/docs/guide/deep_learning/simulator.md
+++ b/docs/guide/deep_learning/simulator.md
@@ -423,10 +423,10 @@ Fields:
 * *pos_x* :  x world coordinate.
 * *pos_y* :  y world coordinate.
 * *pos_z* :  z world coordinate. 
-* *qx* :  (optionnal) quaternion x
-* *qy* :  (optionnal) quaternion y
-* *qz* :  (optionnal) quaternion z
-* *qw* :  (optionnal) quaternion w
+* *Qx* :  (optionnal) quaternion x
+* *Qy* :  (optionnal) quaternion y
+* *Qz* :  (optionnal) quaternion z
+* *Qw* :  (optionnal) quaternion w
 
 Example:
 ```bash
@@ -445,10 +445,10 @@ or:
     "pos_x" : "0.0", 
     "pos_y" : "0.0", 
     "pos_z" : "0.0",
-    "qx" : "0.0",
-    "qy" : "0.2",
-    "qz" : "0.0",
-    "qw" : "1.0"
+    "Qx" : "0.0",
+    "Qy" : "0.2",
+    "Qz" : "0.0",
+    "Qw" : "1.0"
     }
 ```
 
@@ -479,10 +479,10 @@ Fields:
 * *pos_x* :  x world coordinate.
 * *pos_y* :  y world coordinate.
 * *pos_z* :  z world coordinate. 
-* *qx* :  (optionnal) quaternion x
-* *qy* :  (optionnal) quaternion y
-* *qz* :  (optionnal) quaternion z
-* *qw* :  (optionnal) quaternion w
+* *Qx* :  (optionnal) quaternion x
+* *Qy* :  (optionnal) quaternion y
+* *Qz* :  (optionnal) quaternion z
+* *Qw* :  (optionnal) quaternion w
 
 Example:
 ```bash


### PR DESCRIPTION
API format in TcpCarHandler for sdsandbox requires capital Q for quaternion rotation fields.